### PR TITLE
feat: implement server remotes and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# Holla
+# Holla Pager
+
+Lua modules implementing the Holla pager UI for Roblox. All UI is created via code.
+
+## Structure
+
+- `src/Config.lua` – central configuration for webhooks, departments, and data store names.
+- `src/App.lua` – main application controller.
+- `src/pages/*.lua` – individual page constructors (Startup, Home, InGame, Notes, Settings, Help, NoLicense).
+- `src/server/init.server.lua` – creates RemoteEvents/Functions for chat, notes, device requests, and license checks.
+- `src/init.lua` – entry module returning a function to start the app for a player.
+
+The scripts are designed to be inserted into Roblox Studio and required from a LocalScript.

--- a/src/App.lua
+++ b/src/App.lua
@@ -1,0 +1,112 @@
+--!strict
+-- Holla main application entry point
+
+local Players = game:GetService("Players")
+local RunService = game:GetService("RunService")
+local GuiService = game:GetService("GuiService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local Config = require(script.Parent.Config)
+local Pages = script.Parent.pages
+
+local App = {}
+App.__index = App
+
+function App.new(player)
+    local self = setmetatable({}, App)
+    self.Player = player
+    self.Gui = Instance.new("ScreenGui")
+    self.Gui.Name = "HollaGui"
+    self.Gui.IgnoreGuiInset = true
+    self.Gui.ResetOnSpawn = false
+    self.Gui.DisplayOrder = 10
+    self.Gui.Parent = player:WaitForChild("PlayerGui")
+
+    self.Pages = {}
+    self.CurrentPage = nil
+
+    self:loadPages()
+    self:createNavigation()
+    self:showStartup()
+    return self
+end
+
+function App:createNavigation()
+    local button = Instance.new("TextButton")
+    button.Size = UDim2.fromOffset(50,50)
+    button.Text = "\u{1F4E3}" -- megaphone emoji as placeholder logo
+    button.Font = Config.Font
+    button.TextScaled = true
+    button.BackgroundTransparency = 1
+    button.Parent = self.Gui
+
+    local drawer = Instance.new("Frame")
+    drawer.Size = UDim2.new(0,150,1,0)
+    drawer.AnchorPoint = Vector2.new(0,0)
+    drawer.Position = UDim2.new(0,-150,0,0)
+    drawer.BackgroundColor3 = Color3.fromRGB(30,30,30)
+    drawer.BackgroundTransparency = 0.2
+    drawer.Parent = self.Gui
+
+    local layout = Instance.new("UIListLayout")
+    layout.Padding = UDim.new(0,4)
+    layout.FillDirection = Enum.FillDirection.Vertical
+    layout.Parent = drawer
+
+    local function toggle(state)
+        local target = state and 0 or -150
+        drawer:TweenPosition(UDim2.new(0,target,0,0), "Out", "Quad", 0.3, true)
+    end
+
+    local function addButton(label, page)
+        local b = Instance.new("TextButton")
+        b.Size = UDim2.new(1,0,0,40)
+        b.Text = label
+        b.Font = Config.Font
+        b.TextColor3 = Color3.new(1,1,1)
+        b.BackgroundTransparency = 1
+        b.Parent = drawer
+        b.MouseButton1Click:Connect(function()
+            self:showPage(page)
+            toggle(false)
+        end)
+    end
+
+    button.MouseButton1Click:Connect(function()
+        toggle(drawer.Position.X.Offset < 0)
+    end)
+
+    addButton("Home", "Home")
+    addButton("InGame", "InGame")
+    addButton("Notes", "Notes")
+    addButton("Settings", "Settings")
+    addButton("Help", "Help")
+
+    self.NavButton = button
+    self.NavDrawer = drawer
+end
+
+function App:loadPages()
+    for _,module in ipairs(Pages:GetChildren()) do
+        if module:IsA("ModuleScript") then
+            self.Pages[module.Name] = require(module)
+        end
+    end
+end
+
+function App:showPage(name)
+    if self.CurrentPage then
+        self.CurrentPage:Destroy()
+    end
+    local creator = self.Pages[name]
+    if creator then
+        self.CurrentPage = creator(self)
+        self.CurrentPage.Visible = true
+    end
+end
+
+function App:showStartup()
+    self:showPage("Startup")
+end
+
+return App

--- a/src/Config.lua
+++ b/src/Config.lua
@@ -1,0 +1,22 @@
+local Config = {}
+
+-- Placeholder configurable settings for Holla pager
+-- Update these values to customize behavior without editing core code
+
+Config.Webhooks = {
+    default = "https://example.com/webhook"
+}
+
+Config.Departments = {
+    {name = "Nursing", color = Color3.fromRGB(194, 117, 255)},
+    {name = "Pediatrics", color = Color3.fromRGB(255, 182, 193)},
+    {name = "Ortho", color = Color3.fromRGB(130, 202, 156)},
+    {name = "Surgical", color = Color3.fromRGB(255, 214, 165)}
+}
+
+Config.Font = Enum.Font.BuilderSans
+
+Config.NotesDataStore = "HollaNotes"
+Config.DeviceRequestDataStore = "HollaDeviceRequests"
+
+return Config

--- a/src/init.lua
+++ b/src/init.lua
@@ -1,0 +1,5 @@
+local App = require(script.App)
+
+return function(player)
+    return App.new(player)
+end

--- a/src/pages/Help.lua
+++ b/src/pages/Help.lua
@@ -1,0 +1,32 @@
+-- Help page
+local Config = require(script.Parent.Parent.Config)
+
+return function(app)
+    local frame = Instance.new("Frame")
+    frame.Size = UDim2.fromScale(1,1)
+    frame.BackgroundColor3 = Color3.fromRGB(20,20,20)
+    frame.Parent = app.Gui
+
+    local text = Instance.new("TextLabel")
+    text.Size = UDim2.new(1,-40,1,-40)
+    text.Position = UDim2.new(0,20,0,20)
+    text.TextWrapped = true
+    text.Font = Config.Font
+    text.TextColor3 = Color3.new(1,1,1)
+    text.BackgroundTransparency = 1
+    text.Text = [[Help
+
+This product must be purchased from Plover in order for it to work.
+If the owner does not have a valid license to use it, the product will not work.
+
+Please ensure you report any misuse to Plover for handling.
+
+Notify Format:
+@mention(username)
+cc: @mention(HQ)
+Code Blue [location]
+]]
+    text.Parent = frame
+
+    return frame
+end

--- a/src/pages/Home.lua
+++ b/src/pages/Home.lua
@@ -1,0 +1,70 @@
+-- Home page (main chat feed)
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Config = require(script.Parent.Parent.Config)
+
+local ChatEvent = ReplicatedStorage:WaitForChild("HollaChat")
+
+return function(app)
+    local frame = Instance.new("Frame")
+    frame.Size = UDim2.fromScale(1,1)
+    frame.BackgroundTransparency = 1
+    frame.Parent = app.Gui
+
+    local list = Instance.new("ScrollingFrame")
+    list.Size = UDim2.new(1,0,1,-60)
+    list.CanvasSize = UDim2.new()
+    list.BackgroundTransparency = 1
+    list.ScrollBarThickness = 6
+    list.Parent = frame
+
+    local layout = Instance.new("UIListLayout")
+    layout.Padding = UDim.new(0,4)
+    layout.Parent = list
+
+    local input = Instance.new("TextBox")
+    input.Size = UDim2.new(1,-80,0,40)
+    input.Position = UDim2.new(0,20,1,-50)
+    input.BackgroundColor3 = Color3.fromRGB(40,40,40)
+    input.TextColor3 = Color3.new(1,1,1)
+    input.Font = Config.Font
+    input.PlaceholderText = "Say something..."
+    input.ClearTextOnFocus = false
+    input.Parent = frame
+
+    local send = Instance.new("TextButton")
+    send.Size = UDim2.new(0,60,0,40)
+    send.Position = UDim2.new(1,-70,1,-50)
+    send.Text = "Send"
+    send.Font = Config.Font
+    send.BackgroundColor3 = Color3.fromRGB(80,80,80)
+    send.TextColor3 = Color3.new(1,1,1)
+    send.Parent = frame
+
+    local function appendMessage(user, text)
+        local bubble = Instance.new("TextLabel")
+        bubble.Size = UDim2.new(1,-20,0,40)
+        bubble.BackgroundColor3 = Color3.fromRGB(60,60,60)
+        bubble.BackgroundTransparency = 0.5
+        bubble.TextColor3 = Color3.new(1,1,1)
+        bubble.Font = Config.Font
+        bubble.TextXAlignment = Enum.TextXAlignment.Left
+        bubble.TextWrapped = true
+        bubble.Text = string.format("[%s] %s: %s", os.date("%H:%M"), user, text)
+        bubble.Parent = list
+    end
+
+    send.MouseButton1Click:Connect(function()
+        if input.Text ~= "" then
+            ChatEvent:FireServer(input.Text)
+            appendMessage(app.Player.Name, input.Text)
+            input.Text = ""
+        end
+    end)
+
+    ChatEvent.OnClientEvent:Connect(function(sender, msg)
+        appendMessage(sender, msg)
+    end)
+
+    return frame
+end

--- a/src/pages/InGame.lua
+++ b/src/pages/InGame.lua
@@ -1,0 +1,86 @@
+-- In-game player list
+local Players = game:GetService("Players")
+local Config = require(script.Parent.Parent.Config)
+
+return function(app)
+    local frame = Instance.new("Frame")
+    frame.Size = UDim2.fromScale(1,1)
+    frame.BackgroundColor3 = Color3.fromRGB(20,20,20)
+    frame.Parent = app.Gui
+
+    local title = Instance.new("TextLabel")
+    title.Text = "In-Game"
+    title.Size = UDim2.new(1,0,0,50)
+    title.Font = Config.Font
+    title.TextColor3 = Color3.new(1,1,1)
+    title.BackgroundTransparency = 1
+    title.Parent = frame
+
+    local listLayout = Instance.new("UIListLayout")
+    listLayout.Parent = frame
+    listLayout.Padding = UDim.new(0,5)
+    listLayout.SortOrder = Enum.SortOrder.LayoutOrder
+    listLayout.FillDirection = Enum.FillDirection.Vertical
+
+    local function refresh()
+        for _,child in ipairs(frame:GetChildren()) do
+            if child:IsA("Frame") and child ~= title then
+                child:Destroy()
+            end
+        end
+        for _,plr in ipairs(Players:GetPlayers()) do
+            local row = Instance.new("Frame")
+            row.Size = UDim2.new(1,-20,0,50)
+            row.Position = UDim2.new(0,10,0,60)
+            row.BackgroundTransparency = 1
+            row.Parent = frame
+
+            local thumb = Instance.new("ImageLabel")
+            thumb.Size = UDim2.new(0,40,0,40)
+            thumb.Position = UDim2.new(0,0,0,5)
+            thumb.BackgroundTransparency = 1
+            thumb.Parent = row
+            local content, _ = Players:GetUserThumbnailAsync(plr.UserId, Enum.ThumbnailType.HeadShot, Enum.ThumbnailSize.Size48x48)
+            thumb.Image = content
+
+            local name = Instance.new("TextLabel")
+            name.Text = plr.DisplayName
+            name.Font = Config.Font
+            name.TextColor3 = Color3.new(1,1,1)
+            name.BackgroundTransparency = 1
+            name.Size = UDim2.new(1,-140,1,0)
+            name.Position = UDim2.new(0,50,0,0)
+            name.TextXAlignment = Enum.TextXAlignment.Left
+            name.Parent = row
+
+            local tag = Instance.new("TextLabel")
+            tag.Size = UDim2.new(0,80,0,24)
+            tag.Position = UDim2.new(1,-90,0.5,-12)
+            tag.Font = Config.Font
+            tag.TextColor3 = Color3.new(1,1,1)
+            tag.BackgroundColor3 = Color3.fromRGB(150,150,150)
+            tag.Parent = row
+
+            local function updateTag()
+                local dept = plr:GetAttribute("Department") or "None"
+                tag.Text = dept
+                for _,d in ipairs(Config.Departments) do
+                    if d.name == dept then
+                        tag.BackgroundColor3 = d.color
+                        return
+                    end
+                end
+                tag.BackgroundColor3 = Color3.fromRGB(150,150,150)
+            end
+
+            plr:GetAttributeChangedSignal("Department"):Connect(updateTag)
+            updateTag()
+        end
+    end
+
+    refresh()
+    Players.PlayerAdded:Connect(refresh)
+    Players.PlayerRemoving:Connect(refresh)
+
+    return frame
+end

--- a/src/pages/NoLicense.lua
+++ b/src/pages/NoLicense.lua
@@ -1,0 +1,20 @@
+-- Shown when license check fails
+local Config = require(script.Parent.Parent.Config)
+
+return function(app)
+    local frame = Instance.new("Frame")
+    frame.Size = UDim2.fromScale(1,1)
+    frame.BackgroundColor3 = Color3.new(0,0,0)
+    frame.Parent = app.Gui
+
+    local text = Instance.new("TextLabel")
+    text.Text = "Error: No license. Contact Support."
+    text.Font = Config.Font
+    text.TextColor3 = Color3.new(1,1,1)
+    text.BackgroundTransparency = 1
+    text.AnchorPoint = Vector2.new(0.5,0.5)
+    text.Position = UDim2.fromScale(0.5,0.5)
+    text.Parent = frame
+
+    return frame
+end

--- a/src/pages/Notes.lua
+++ b/src/pages/Notes.lua
@@ -1,0 +1,76 @@
+-- Notes page with persistence
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Config = require(script.Parent.Parent.Config)
+
+local SaveNotes = ReplicatedStorage:WaitForChild("SaveNotes")
+local LoadNotes = ReplicatedStorage:WaitForChild("LoadNotes")
+
+return function(app)
+    local frame = Instance.new("Frame")
+    frame.Size = UDim2.fromScale(1,1)
+    frame.BackgroundColor3 = Color3.fromRGB(0,0,0)
+    frame.Parent = app.Gui
+
+    local box = Instance.new("TextBox")
+    box.Size = UDim2.new(1,-40,1,-100)
+    box.Position = UDim2.new(0,20,0,20)
+    box.TextWrapped = true
+    box.TextXAlignment = Enum.TextXAlignment.Left
+    box.TextYAlignment = Enum.TextYAlignment.Top
+    box.ClearTextOnFocus = false
+    box.Font = Config.Font
+    box.TextColor3 = Color3.new(1,1,1)
+    box.BackgroundColor3 = Color3.fromRGB(40,40,40)
+    box.Parent = frame
+
+    local loaded
+    pcall(function()
+        loaded = LoadNotes:InvokeServer()
+    end)
+    if loaded then
+        box.Text = loaded
+    end
+
+    local function save()
+        pcall(function()
+            SaveNotes:InvokeServer(box.Text)
+        end)
+    end
+
+    box.FocusLost:Connect(save)
+
+    local clear = Instance.new("TextButton")
+    clear.Text = "Clear"
+    clear.Font = Config.Font
+    clear.Size = UDim2.new(0,80,0,40)
+    clear.Position = UDim2.new(0,20,1,-50)
+    clear.Parent = frame
+    clear.MouseButton1Click:Connect(function()
+        box.Text = ""
+        save()
+    end)
+
+    local share = Instance.new("TextButton")
+    share.Text = "Share"
+    share.Font = Config.Font
+    share.Size = UDim2.new(0,80,0,40)
+    share.Position = UDim2.new(0,110,1,-50)
+    share.Parent = frame
+    share.MouseButton1Click:Connect(function()
+        -- Placeholder for future sharing logic
+    end)
+
+    local back = Instance.new("TextButton")
+    back.Text = "Back"
+    back.Font = Config.Font
+    back.Size = UDim2.new(0,80,0,40)
+    back.Position = UDim2.new(1,-100,1,-50)
+    back.AnchorPoint = Vector2.new(0,0)
+    back.Parent = frame
+    back.MouseButton1Click:Connect(function()
+        save()
+        app:showPage("Home")
+    end)
+
+    return frame
+end

--- a/src/pages/Settings.lua
+++ b/src/pages/Settings.lua
@@ -1,0 +1,103 @@
+-- Settings page
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Config = require(script.Parent.Parent.Config)
+
+local RequestDevice = ReplicatedStorage:WaitForChild("RequestDevice")
+
+return function(app)
+    local frame = Instance.new("Frame")
+    frame.Size = UDim2.fromScale(1,1)
+    frame.BackgroundColor3 = Color3.fromRGB(20,20,20)
+    frame.Parent = app.Gui
+
+    local title = Instance.new("TextLabel")
+    title.Text = "Settings"
+    title.Size = UDim2.new(1,0,0,50)
+    title.Font = Config.Font
+    title.TextColor3 = Color3.new(1,1,1)
+    title.BackgroundTransparency = 1
+    title.Parent = frame
+
+    local audioToggle = Instance.new("TextButton")
+    audioToggle.Text = "Audio: On"
+    audioToggle.Size = UDim2.new(0,120,0,40)
+    audioToggle.Position = UDim2.new(0,20,0,70)
+    audioToggle.Font = Config.Font
+    audioToggle.BackgroundColor3 = Color3.fromRGB(60,60,60)
+    audioToggle.TextColor3 = Color3.new(1,1,1)
+    audioToggle.Parent = frame
+
+    local function toggle(btn)
+        local state = btn:GetAttribute("State")
+        state = not state
+        btn:SetAttribute("State", state)
+        btn.Text = (state and "On" or "Off")
+    end
+
+    audioToggle:SetAttribute("State", true)
+    audioToggle.MouseButton1Click:Connect(function()
+        toggle(audioToggle)
+    end)
+
+    local notifToggle = audioToggle:Clone()
+    notifToggle.Text = "Notifications: On"
+    notifToggle.Position = UDim2.new(0,20,0,120)
+    notifToggle.Parent = frame
+    notifToggle.MouseButton1Click:Connect(function()
+        toggle(notifToggle)
+    end)
+
+    local deptLabel = Instance.new("TextLabel")
+    deptLabel.Text = "Department"
+    deptLabel.Position = UDim2.new(0,20,0,180)
+    deptLabel.Font = Config.Font
+    deptLabel.TextColor3 = Color3.new(1,1,1)
+    deptLabel.BackgroundTransparency = 1
+    deptLabel.Parent = frame
+
+    local deptList = Instance.new("Frame")
+    deptList.Size = UDim2.new(0,200,0,150)
+    deptList.Position = UDim2.new(0,20,0,210)
+    deptList.BackgroundTransparency = 1
+    deptList.Parent = frame
+
+    local layout = Instance.new("UIListLayout")
+    layout.Parent = deptList
+    layout.Padding = UDim.new(0,4)
+
+    for _,dept in ipairs(Config.Departments) do
+        local btn = Instance.new("TextButton")
+        btn.Size = UDim2.new(1,0,0,30)
+        btn.BackgroundColor3 = dept.color
+        btn.Text = dept.name
+        btn.Font = Config.Font
+        btn.TextColor3 = Color3.new(1,1,1)
+        btn.Parent = deptList
+        btn.MouseButton1Click:Connect(function()
+            app.Player:SetAttribute("Department", dept.name)
+        end)
+    end
+
+    local orgLabel = Instance.new("TextLabel")
+    orgLabel.Text = "My Organization"
+    orgLabel.Position = UDim2.new(0,20,0,380)
+    orgLabel.Size = UDim2.new(0,200,0,30)
+    orgLabel.Font = Config.Font
+    orgLabel.TextColor3 = Color3.new(1,1,1)
+    orgLabel.BackgroundTransparency = 1
+    orgLabel.Parent = frame
+
+    local request = Instance.new("TextButton")
+    request.Text = "Request Device"
+    request.Font = Config.Font
+    request.Size = UDim2.new(0,150,0,40)
+    request.Position = UDim2.new(0,20,0,420)
+    request.BackgroundColor3 = Color3.fromRGB(60,60,60)
+    request.TextColor3 = Color3.new(1,1,1)
+    request.Parent = frame
+    request.MouseButton1Click:Connect(function()
+        RequestDevice:FireServer("Request from "..app.Player.Name)
+    end)
+
+    return frame
+end

--- a/src/pages/Startup.lua
+++ b/src/pages/Startup.lua
@@ -1,0 +1,48 @@
+-- Startup screen module
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Config = require(script.Parent.Parent.Config)
+
+local CheckLicense = ReplicatedStorage:WaitForChild("CheckLicense")
+
+return function(app)
+    local gui = Instance.new("Frame")
+    gui.Size = UDim2.fromScale(1,1)
+    gui.BackgroundColor3 = Color3.new(0,0,0)
+    gui.Parent = app.Gui
+
+    local logo = Instance.new("TextLabel")
+    logo.Size = UDim2.new(0,0,0,0)
+    logo.AnchorPoint = Vector2.new(0.5,0.5)
+    logo.Position = UDim2.fromScale(0.5,0.4)
+    logo.Font = Config.Font
+    logo.Text = "Holla'"
+    logo.TextColor3 = Color3.new(1,1,1)
+    logo.BackgroundTransparency = 1
+    logo.Parent = gui
+    logo.TextScaled = true
+
+    local bar = Instance.new("Frame")
+    bar.Size = UDim2.new(0,0,0,6)
+    bar.AnchorPoint = Vector2.new(0,0.5)
+    bar.Position = UDim2.new(0.2,0,0.7,0)
+    bar.BackgroundColor3 = Color3.fromRGB(80,80,80)
+    bar.Parent = gui
+
+    task.spawn(function()
+        for i=1,20 do
+            bar.Size = UDim2.new(0.03*i,0,0,6)
+            task.wait(0.05)
+        end
+        local ok = false
+        pcall(function()
+            ok = CheckLicense:InvokeServer()
+        end)
+        if ok then
+            app:showPage("Home")
+        else
+            app:showPage("NoLicense")
+        end
+    end)
+
+    return gui
+end

--- a/src/server/init.server.lua
+++ b/src/server/init.server.lua
@@ -1,0 +1,84 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Players = game:GetService("Players")
+local DataStoreService = game:GetService("DataStoreService")
+
+local Config = require(script.Parent.Parent.Config)
+
+-- Remote definitions
+local ChatEvent = Instance.new("RemoteEvent")
+ChatEvent.Name = "HollaChat"
+ChatEvent.Parent = ReplicatedStorage
+
+local CheckLicense = Instance.new("RemoteFunction")
+CheckLicense.Name = "CheckLicense"
+CheckLicense.Parent = ReplicatedStorage
+
+local SaveNotes = Instance.new("RemoteFunction")
+SaveNotes.Name = "SaveNotes"
+SaveNotes.Parent = ReplicatedStorage
+
+local LoadNotes = Instance.new("RemoteFunction")
+LoadNotes.Name = "LoadNotes"
+LoadNotes.Parent = ReplicatedStorage
+
+local RequestDevice = Instance.new("RemoteEvent")
+RequestDevice.Name = "RequestDevice"
+RequestDevice.Parent = ReplicatedStorage
+
+-- DataStores
+local noteStore = DataStoreService:GetDataStore(Config.NotesDataStore)
+local requestStore = DataStoreService:GetDataStore(Config.DeviceRequestDataStore)
+
+-- Chat relay
+ChatEvent.OnServerEvent:Connect(function(player, message)
+    ChatEvent:FireAllClients(player.Name, message)
+end)
+
+-- License check placeholder - always true
+CheckLicense.OnServerInvoke = function(player)
+    return true
+end
+
+-- Notes save/load
+SaveNotes.OnServerInvoke = function(player, text)
+    local success, err = pcall(function()
+        noteStore:SetAsync(player.UserId, text)
+    end)
+    if not success then
+        warn("Failed to save notes: "..tostring(err))
+    end
+    return success
+end
+
+LoadNotes.OnServerInvoke = function(player)
+    local success, data = pcall(function()
+        return noteStore:GetAsync(player.UserId)
+    end)
+    if success then
+        return data or ""
+    else
+        warn("Failed to load notes: "..tostring(data))
+        return ""
+    end
+end
+
+-- Device request
+RequestDevice.OnServerEvent:Connect(function(player, payload)
+    local data = {
+        userId = player.UserId,
+        message = payload,
+        time = os.time(),
+    }
+    pcall(function()
+        requestStore:UpdateAsync("queue", function(old)
+            old = old or {}
+            table.insert(old, data)
+            return old
+        end)
+    end)
+end)
+
+-- Track department attribute for players
+Players.PlayerAdded:Connect(function(player)
+    player:SetAttribute("Department", "")
+end)


### PR DESCRIPTION
## Summary
- add server script establishing remotes for chat, license checks, notes persistence, and device requests
- build navigation drawer and startup license verification
- hook notes, settings, and in-game pages to new remotes and add player avatars

## Testing
- `luacheck src`

------
https://chatgpt.com/codex/tasks/task_e_68bf69cec89483289b9566fc958d0668